### PR TITLE
Append abcdefg to the readme file in the repo using echo command...

### DIFF
--- a/readme
+++ b/readme
@@ -1,0 +1,1 @@
+abcdefg


### PR DESCRIPTION
You can append text to a file in a Unix-based system using the `echo` command and the `>>` operator. Here's how you can append "abcdefg" to the `readme` file in your current directory:

```bash
echo "abcdefg" >> readme
```

This command will not overwrite the existing content of the `readme` file. Instead, it will add "abcdefg" to the end of the file. If the `readme` file does not exist, this command will create it.

Please replace `readme` with the actual path to your readme file if it's not in the current directory. For example, if your readme file is in a directory named `repo`, you would use:

```bash
echo "abcdefg" >> repo/readme
```